### PR TITLE
Remove extra newline

### DIFF
--- a/python/mt_prepend_gtf.py
+++ b/python/mt_prepend_gtf.py
@@ -23,7 +23,7 @@ def parse_args():
 def main(args):
     for line in args.gtf:
         if line.startswith('#'):
-            print(line)
+            print(line.rstrip())
             continue
 
         record = gtfez.GTFRecord(line)

--- a/test/test_in.gtf
+++ b/test/test_in.gtf
@@ -1,3 +1,4 @@
+#comment
 MT	RefSeq	gene	2747	3703	.	+	.	gene_id "ENSCAFG00000022713"; gene_version "1"; gene_name "MT-ND1"; gene_source "RefSeq"; gene_biotype "protein_coding";
 MT	RefSeq	transcript	2747	3703	.	+	.	gene_id "ENSCAFG00000022713"; gene_version "1"; transcript_id "ENSCAFT00000034820"; transcript_version "1"; gene_name "MT-ND1"; gene_source "RefSeq"; gene_biotype "protein_coding"; transcript_name "MT-ND1-201"; transcript_source "RefSeq"; transcript_biotype "protein_coding";
 MT	RefSeq	exon	2747	3703	.	+	.	gene_id "ENSCAFG00000022713"; gene_version "1"; transcript_id "ENSCAFT00000034820"; transcript_version "1"; exon_number "1"; gene_name "MT-ND1"; gene_source "RefSeq"; gene_biotype "protein_coding"; transcript_name "MT-ND1-201"; transcript_source "RefSeq"; transcript_biotype "protein_coding"; exon_id "ENSCAFE00000226329"; exon_version "1";

--- a/test/test_out.gtf
+++ b/test/test_out.gtf
@@ -1,3 +1,4 @@
+#comment
 MT	RefSeq	gene	2747	3703	.	+	.	gene_id "ENSCAFG00000022713"; gene_version "1"; gene_name "MT-ND1"; gene_source "RefSeq"; gene_biotype "protein_coding";
 MT	RefSeq	transcript	2747	3703	.	+	.	gene_id "ENSCAFG00000022713"; gene_version "1"; transcript_id "ENSCAFT00000034820"; transcript_version "1"; gene_name "MT-ND1"; gene_source "RefSeq"; gene_biotype "protein_coding"; transcript_name "MT-ND1-201"; transcript_source "RefSeq"; transcript_biotype "protein_coding";
 MT	RefSeq	exon	2747	3703	.	+	.	gene_id "ENSCAFG00000022713"; gene_version "1"; transcript_id "ENSCAFT00000034820"; transcript_version "1"; exon_number "1"; gene_name "MT-ND1"; gene_source "RefSeq"; gene_biotype "protein_coding"; transcript_name "MT-ND1-201"; transcript_source "RefSeq"; transcript_biotype "protein_coding"; exon_id "ENSCAFE00000226329"; exon_version "1";


### PR DESCRIPTION
Removing newline from comments renders the original comment when `print`ed.